### PR TITLE
DAO cleanup

### DIFF
--- a/src/dao/channel_dao_postgres.rs
+++ b/src/dao/channel_dao_postgres.rs
@@ -1,9 +1,9 @@
-use dao::{ChannelDao, ChannelDaoPostgres};
+use dao::{ChannelDao, DaoPostgres};
 use error::Error;
 use project_types::Channel;
 
 
-impl ChannelDao for ChannelDaoPostgres {
+impl ChannelDao for DaoPostgres {
     /// Fetch a Channel with the given channel id
     fn get_channel(&self, chanid: u32) -> Result<Channel, Error> {
         let query = "SELECT name,primary_num,secondary_num,color,channel_internal,channel_dmx, \

--- a/src/dao/daos.rs
+++ b/src/dao/daos.rs
@@ -2,6 +2,18 @@ use error::Error;
 use project_types::{Channel, Fixture, Layout, Permission, Project, Section, Sequence, User};
 
 
+// Aggregate trait type containing all of the daos
+pub trait ProtonDao:
+    ChannelDao
+    + DataDao
+    + FixtureDao
+    + LayoutDao
+    + PermissionDao
+    + ProjectDao
+    + SectionDao
+    + SequenceDao
+    + UserDao {}
+
 /// Handles metadata related to channels
 pub trait ChannelDao {
     /// Add a channel

--- a/src/dao/daos_postgres.rs
+++ b/src/dao/daos_postgres.rs
@@ -8,17 +8,7 @@ pub struct DaoPostgres {
     pub conn: Connection
 }
 
-pub type ChannelDaoPostgres = DaoPostgres;
-pub type DataDaoPostgres = DaoPostgres;
-pub type FixtureDaoPostgres = DaoPostgres;
-pub type LayoutDaoPostgres = DaoPostgres;
-pub type PermissionDaoPostgres = DaoPostgres;
-pub type ProjectDaoPostgres = DaoPostgres;
-pub type SectionDaoPostgres = DaoPostgres;
-pub type SequenceDaoPostgres = DaoPostgres;
-pub type UserDaoPostgres = DaoPostgres;
-
-
+// DaoPostgres-specific functions
 impl DaoPostgres {
     pub fn new() -> Result<DaoPostgres, Error> {
         let conn = try!(get_connection());

--- a/src/dao/data_dao_postgres.rs
+++ b/src/dao/data_dao_postgres.rs
@@ -1,8 +1,8 @@
-use dao::{DataDao, DataDaoPostgres};
+use dao::{DataDao, DaoPostgres};
 use error::Error;
 
 
-impl DataDao for DataDaoPostgres {
+impl DataDao for DaoPostgres {
 
     fn new_data_default(
         &self,

--- a/src/dao/fixture_dao_postgres.rs
+++ b/src/dao/fixture_dao_postgres.rs
@@ -1,8 +1,8 @@
 use project_types::Fixture;
 use error::Error;
-use dao::{FixtureDao, FixtureDaoPostgres};
+use dao::{FixtureDao, DaoPostgres};
 
-impl FixtureDao for FixtureDaoPostgres {
+impl FixtureDao for DaoPostgres {
 
     fn new_fixture(
         &self, 

--- a/src/dao/layout_dao_postgres.rs
+++ b/src/dao/layout_dao_postgres.rs
@@ -1,9 +1,9 @@
 use project_types::Layout;
 use error::Error;
-use dao::{LayoutDao, LayoutDaoPostgres};
+use dao::{LayoutDao, DaoPostgres};
 
 
-impl LayoutDao for LayoutDaoPostgres {
+impl LayoutDao for DaoPostgres {
 
     fn new_layout(&self, name: &str, fixtures: Vec<u32>) -> Result<Layout, Error> {
         let statement = "INSERT INTO layouts (name,fixtures) VALUES ($1,$2)";

--- a/src/dao/mod.rs
+++ b/src/dao/mod.rs
@@ -2,6 +2,8 @@
 // DAO traits/interfaces
 mod daos;
 
+pub use self::daos::ProtonDao;
+
 pub use self::daos::ChannelDao;
 pub use self::daos::DataDao;
 pub use self::daos::FixtureDao;
@@ -14,6 +16,13 @@ pub use self::daos::UserDao;
 
 // Postgres implementations
 mod daos_postgres;
+pub use self::daos_postgres::DaoPostgres;
+
+// Connection configuration
+mod connection_config;
+use self::connection_config::ConnectionConfig;
+
+// Load postgres implementations to show that ProtonDao is satisfied
 mod channel_dao_postgres;
 mod data_dao_postgres;
 mod fixture_dao_postgres;
@@ -24,16 +33,5 @@ mod section_dao_postgres;
 mod sequence_dao_postgres;
 mod user_dao_postgres;
 
-pub use self::daos_postgres::ChannelDaoPostgres;
-pub use self::daos_postgres::DataDaoPostgres;
-pub use self::daos_postgres::FixtureDaoPostgres;
-pub use self::daos_postgres::LayoutDaoPostgres;
-pub use self::daos_postgres::PermissionDaoPostgres;
-pub use self::daos_postgres::ProjectDaoPostgres;
-pub use self::daos_postgres::SectionDaoPostgres;
-pub use self::daos_postgres::SequenceDaoPostgres;
-pub use self::daos_postgres::UserDaoPostgres;
-
-// Connection configuration
-mod connection_config;
-use self::connection_config::ConnectionConfig;
+// Make DaoPostgres conform to the ProtonDao interface (follow all Daos)
+impl ProtonDao for DaoPostgres {}

--- a/src/dao/permission_dao_postgres.rs
+++ b/src/dao/permission_dao_postgres.rs
@@ -1,9 +1,9 @@
 use project_types::{self, Permission};
-use dao::{PermissionDao, PermissionDaoPostgres};
+use dao::{PermissionDao, DaoPostgres};
 use error::Error;
 
 
-impl PermissionDao for PermissionDaoPostgres {
+impl PermissionDao for DaoPostgres {
 
     fn add_initial_permission(&self, root_uid: u32) -> Result<(), Error> {
         let statement = "INSERT INTO permissions (uid, seqid, secid, permission) VALUES ($1, $2, $3, $4)";

--- a/src/dao/project_dao_postgres.rs
+++ b/src/dao/project_dao_postgres.rs
@@ -1,8 +1,8 @@
 use project_types::Project;
 use error::Error;
-use dao::{ProjectDao, ProjectDaoPostgres};
+use dao::{ProjectDao, DaoPostgres};
 
-impl ProjectDao for ProjectDaoPostgres {
+impl ProjectDao for DaoPostgres {
     fn new_project(&self, name: &str, layout_id: u32) -> Result<Project, Error> {
         let statement = "INSERT INTO projects (name,playlist,layoutid) VALUES ($1,$2,$3)";
         let playlist: Vec<i32> = Vec::new();

--- a/src/dao/section_dao_postgres.rs
+++ b/src/dao/section_dao_postgres.rs
@@ -1,9 +1,9 @@
 use project_types::Section;
-use dao::{SectionDao, SectionDaoPostgres};
+use dao::{SectionDao, DaoPostgres};
 use error::Error;
 
 
-impl SectionDao for SectionDaoPostgres {
+impl SectionDao for DaoPostgres {
 
     #[allow(unused_variables)]
     fn get_section(&self, secid: u32) -> Result<Section, Error> {

--- a/src/dao/sequence_dao_postgres.rs
+++ b/src/dao/sequence_dao_postgres.rs
@@ -1,9 +1,9 @@
-use dao::{SequenceDao, SequenceDaoPostgres};
+use dao::{SequenceDao, DaoPostgres};
 use error::Error;
 use project_types::Sequence;
 
 
-impl SequenceDao for SequenceDaoPostgres {
+impl SequenceDao for DaoPostgres {
 
     fn get_channel_ids(&self, seqid: u32) -> Result<Vec<u32>, Error> {
         let query = "SELECT chanid FROM \

--- a/src/dao/user_dao_postgres.rs
+++ b/src/dao/user_dao_postgres.rs
@@ -1,9 +1,9 @@
-use dao::{UserDao, UserDaoPostgres};
+use dao::{UserDao, DaoPostgres};
 use error::Error;
 use project_types::User;
 
 
-impl UserDao for UserDaoPostgres {
+impl UserDao for DaoPostgres {
 
     fn add_initial_user(&self, proj_name: &str, private_key: &str, public_key: &str) -> Result<u32, Error> {
         let root_uname = format!("{}_{}", "root", proj_name);

--- a/src/layout.rs
+++ b/src/layout.rs
@@ -3,15 +3,15 @@
 use rustc_serialize::json;
 use std::path::Path;
 
-use dao::{ChannelDao, FixtureDao, LayoutDao, SequenceDao};
+use dao::ProtonDao;
 use error::Error;
 use project_types::{FileLayout, FilePatch};
 use utils;
 
 
 /// Patches a layout's channels based on a provided patch file
-pub fn patch_layout<P: AsRef<Path>, LD: LayoutDao> (
-    layout_dao: &LD,
+pub fn patch_layout<P: AsRef<Path>, PD: ProtonDao> (
+    dao: &PD,
     layout_id: u32,
     patch_file_path: P
 ) -> Result<(), Error> {
@@ -25,7 +25,7 @@ pub fn patch_layout<P: AsRef<Path>, LD: LayoutDao> (
 
     // Apply patch
     for patch in patch_file.patches.iter() {
-        match layout_dao.patch_channel(layout_id, patch.internalChannel, patch.dmxChannel) {
+        match dao.patch_channel(layout_id, patch.internalChannel, patch.dmxChannel) {
             Ok(1) => {},
             Ok(0) => println!("No channels patched. vix: {}, dmx: {}", patch.internalChannel, patch.dmxChannel),
             Ok(num_ch) => println!("Patched {} channels.", num_ch),
@@ -37,10 +37,8 @@ pub fn patch_layout<P: AsRef<Path>, LD: LayoutDao> (
 }
 
 /// Creates a new layout
-pub fn new_layout<P: AsRef<Path>, CD: ChannelDao, FD: FixtureDao, LD: LayoutDao>(
-    chan_dao: &CD,
-    fix_dao: &FD,
-    layout_dao: &LD,
+pub fn new_layout<P: AsRef<Path>, PD: ProtonDao>(
+    dao: &PD,
     layout_path: P,
 ) -> Result<u32, Error> {
 
@@ -52,38 +50,37 @@ pub fn new_layout<P: AsRef<Path>, CD: ChannelDao, FD: FixtureDao, LD: LayoutDao>
     try!(file_layout.validate());
 
     // Create new channels and fixtures from layout and add to storage
-    let (_, fixtures) = try!(file_layout.create_new_parts(chan_dao, fix_dao));
+    let (_, fixtures) = try!(file_layout.create_new_parts(dao));
 
     // Create new layout from fixtures
     let fix_ids = fixtures.iter()
         .map(|fixture| fixture.fixid)
         .collect::<Vec<u32>>();
-    let layout = try!(layout_dao.new_layout(&file_layout.layoutName, fix_ids));
+    let layout = try!(dao.new_layout(&file_layout.layoutName, fix_ids));
 
     // Return layout id
     Ok(layout.layout_id)
 }
 
 /// Set a layout's sequence
-pub fn set_sequence_layout<LD: LayoutDao, SD: SequenceDao>(
-    layout_dao: &LD,
-    sequence_dao: &SD,
+pub fn set_sequence_layout<PD: ProtonDao>(
+    dao: &PD,
     layout_id: u32,
     seqid: u32
 ) -> Result<(), Error> {
 
 
     // Check that sequence exists
-    let sequence = try!(sequence_dao.get_sequence(seqid));
+    let sequence = try!(dao.get_sequence(seqid));
 
     // Check that current layout exists
-    try!(layout_dao.layout_exists(sequence.layout_id));
+    try!(dao.layout_exists(sequence.layout_id));
     
     // Check that new layout exists
-    try!(layout_dao.layout_exists(layout_id));
+    try!(dao.layout_exists(layout_id));
 
     // Set sequence layout id
-    try!(sequence_dao.set_layout(seqid, layout_id));
+    try!(dao.set_layout(seqid, layout_id));
 
     Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use rustc_serialize::json;
 use docopt::Docopt;
 
 use proton_cli::error::Error;
-use proton_cli::dao::{self, LayoutDao};
+use proton_cli::dao::{DaoPostgres, ProtonDao};
 use proton_cli::project_types::{PermissionEnum, Project, Sequence, User};
 use proton_cli::utils;
 
@@ -92,8 +92,15 @@ fn main() {
 	
 	// Below unwrap()'s are safe within Docopt's usage rules
 
+	// Create data access object for data retrieval from database, file, etc.
+	// Use only Postgres for now
+	let psql_dao = match DaoPostgres::new() {
+		Ok(d) => d,
+		Err(e) => panic!("Failed to retrieve DAO: {}", e)
+	};
+
 	// Every proton command is mapped to a specific function that should be run
-	let command: fn(Args) -> Result<ProtonReturn, Error> = match env::args().nth(1).unwrap().as_ref() {
+	let command: fn(Args, DaoPostgres) -> Result<ProtonReturn, Error> = match env::args().nth(1).unwrap().as_ref() {
 		"delete-sequence" => run_delete_sequence,
 		"get-layout-id" => run_get_layout_id,
 		"get-playlist-data" => run_get_playlist_data,
@@ -117,7 +124,7 @@ fn main() {
 	};
 
 	// Run the appropriate command and handle its return
-	let result = command(args);
+	let result = command(args, psql_dao);
 	match result {
 		Ok(ret) => match ret {
 			ProtonReturn::LayoutId(lid) => println!("Layout id: {}", lid),
@@ -136,148 +143,103 @@ fn main() {
 	};
 }
 
-fn run_delete_sequence(args: Args) -> Result<ProtonReturn, Error> {
+fn run_delete_sequence<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let admin_key = args.arg_admin_key.unwrap();
 	let admin_key_path = Path::new(&admin_key);
 	let seqid = args.arg_seqid.unwrap();
-	let user_dao = try!(dao::UserDaoPostgres::new());
-	let perm_dao = try!(dao::PermissionDaoPostgres::new());
-	let sequence_dao = try!(dao::SequenceDaoPostgres::new());
-
 	
-	try!(proton_cli::delete_sequence(
-		&user_dao,
-		&perm_dao,
-		&sequence_dao,
-		&admin_key_path,
-		seqid));
+	try!(proton_cli::delete_sequence(&dao, &admin_key_path, seqid));
 	Ok(ProtonReturn::NoReturn)
 }
 
 /// get-layout-id <proj-name>
-fn run_get_layout_id(args: Args) -> Result<ProtonReturn, Error> {
+fn run_get_layout_id<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let proj_name = args.arg_proj_name.unwrap();
-	let proj_dao = try!(dao::ProjectDaoPostgres::new());
-	let layout_id = try!(proton_cli::get_layout_id(&proj_dao, &proj_name));
+	let layout_id = try!(proton_cli::get_layout_id(&dao, &proj_name));
 	Ok(ProtonReturn::LayoutId(layout_id))
 }
 
 /// get-playlist-data <proj-name>
-fn run_get_playlist_data(args: Args) -> Result<ProtonReturn, Error> {
+fn run_get_playlist_data<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let proj_name = args.arg_proj_name.unwrap();
-	let channel_dao = try!(dao::ChannelDaoPostgres::new());
-	let data_dao = try!(dao::DataDaoPostgres::new());
-	let proj_dao = try!(dao::ProjectDaoPostgres::new());
-	let seq_dao = try!(dao::SequenceDaoPostgres::new());
-	let data = try!(proton_cli::get_playlist_data(
-		&channel_dao,
-		&data_dao,
-		&proj_dao,
-		&seq_dao,
-		&proj_name));
+	let data = try!(proton_cli::get_playlist_data(&dao, &proj_name));
 	Ok(ProtonReturn::PlaylistData(data))
 }
 
 /// get-project <proj-name>
-fn run_get_project(args: Args) -> Result<ProtonReturn, Error> {
+fn run_get_project<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let proj_name = args.arg_proj_name.unwrap();
-	let proj_dao = try!(dao::ProjectDaoPostgres::new());
-	let project = try!(proton_cli::get_project(&proj_dao, &proj_name));
+	let project = try!(proton_cli::get_project(&dao, &proj_name));
 	Ok(ProtonReturn::Project(project))
 }
 
 /// get-sequence <seqid>
-fn run_get_sequence(args: Args) -> Result<ProtonReturn, Error> {
+fn run_get_sequence<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let seqid = args.arg_seqid.unwrap();
-	let seq_dao = try!(dao::SequenceDaoPostgres::new());
-	let sequence = try!(proton_cli::get_sequence(&seq_dao, seqid));
+	let sequence = try!(proton_cli::get_sequence(&dao, seqid));
 	Ok(ProtonReturn::Sequence(sequence))
 }
 
 /// get-user <public-key>
-fn run_get_user(args: Args) -> Result<ProtonReturn, Error> {
+fn run_get_user<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let public_key = args.arg_public_key.unwrap();
 	let public_key_path = Path::new(&public_key);
-	let user_dao = try!(dao::UserDaoPostgres::new());
-	let user = try!(proton_cli::get_user(user_dao, &public_key_path));
+	let user = try!(proton_cli::get_user(&dao, &public_key_path));
 	Ok(ProtonReturn::User(user))
 }
 
 /// insert-sequence <admin-key> <proj-name> <seqid> [<index>]
-fn run_insert_sequence(args: Args) -> Result<ProtonReturn, Error> {
+fn run_insert_sequence<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let admin_key = args.arg_admin_key.unwrap();
 	let admin_key_path = Path::new(&admin_key);
 	let proj_name = args.arg_proj_name.unwrap();
 	let seqid = args.arg_seqid.unwrap();
 	let index = args.arg_index;
 
-	let perm_dao = try!(dao::PermissionDaoPostgres::new());
-	let project_dao = try!(dao::ProjectDaoPostgres::new());
-	let seq_dao = try!(dao::SequenceDaoPostgres::new());
-	let user_dao = try!(dao::UserDaoPostgres::new());
-
 	let valid_permissions = vec![PermissionEnum::Administrate];
-    let _ = try!(utils::check_valid_permission(
-        &perm_dao,
-        &user_dao,
-        admin_key_path,
-        &valid_permissions));
+	let _ = try!(utils::check_valid_permission(
+		&dao,
+		admin_key_path,
+		&valid_permissions));
 	
-	try!(proton_cli::insert_sequence(&project_dao, &seq_dao, &proj_name, seqid, index));
+	try!(proton_cli::insert_sequence(&dao, &proj_name, seqid, index));
 	Ok(ProtonReturn::NoReturn)
 }
 
 /// list-permissions <uid>
-fn run_list_permissions(args: Args) -> Result<ProtonReturn, Error> {
+fn run_list_permissions<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let uid = args.arg_uid.unwrap();
-	let perm_dao = try!(dao::PermissionDaoPostgres::new());
 	let permissions = try!(
-		proton_cli::get_permissions::<String, dao::PermissionDaoPostgres>(perm_dao, uid));
+		proton_cli::get_permissions(&dao, uid)
+	);
 	println!("{}", json::as_pretty_json(&permissions));
 	Ok(ProtonReturn::NoReturn)
 }
 
 /// new-layout <layout-file>
-fn run_new_layout(args: Args) -> Result<ProtonReturn, Error> {
+fn run_new_layout<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let layout_file = args.arg_layout_file.unwrap();
 	let layout_file_path = Path::new(&layout_file);
-	let channel_dao = try!(dao::ChannelDaoPostgres::new());
-	let fixture_dao = try!(dao::FixtureDaoPostgres::new());
-	let layout_dao = try!(dao::LayoutDaoPostgres::new());
-	let layout_id = try!(proton_cli::new_layout(
-		&channel_dao,
-		&fixture_dao,
-		&layout_dao,
-		&layout_file_path));
+	let layout_id = try!(proton_cli::new_layout(&dao, &layout_file_path));
 	Ok(ProtonReturn::LayoutId(layout_id))
 }
 
 /// new-project <name> <layout-id>
-fn run_new_project(args: Args) -> Result<ProtonReturn, Error> {
+fn run_new_project<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let name = args.arg_name.unwrap();
 	let layout_id = args.arg_layout_id.unwrap();
-	let layout_dao = try!(dao::LayoutDaoPostgres::new());
-	let perm_dao = try!(dao::PermissionDaoPostgres::new());
-	let project_dao = try!(dao::ProjectDaoPostgres::new());
-	let user_dao = try!(dao::UserDaoPostgres::new());
-	let root_pub_key = try!(proton_cli::new_project(
-		&layout_dao,
-		&perm_dao,
-		&project_dao,
-		&user_dao,
-		&name,
-		layout_id));
+	let root_pub_key = try!(proton_cli::new_project(&dao, &name, layout_id));
 	Ok(ProtonReturn::PublicKey(root_pub_key))
 }
 
 /// new-section <admin-key> <t_start> <t_end> <seqid> <fixid>..
 #[allow(unused_variables)]
-fn run_new_section(args: Args) -> Result<ProtonReturn, Error> {
+fn run_new_section<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	Err(Error::TodoErr)
 }
 
 /// new-sequence <admin-key> <name> <music-file> <seq-duration> <layout-id>
-fn run_new_sequence(args: Args) -> Result<ProtonReturn, Error> {
+fn run_new_sequence<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let admin_key = args.arg_admin_key.unwrap();
 	let admin_key_path = Path::new(&admin_key);
 	let name = args.arg_name.unwrap();
@@ -285,24 +247,16 @@ fn run_new_sequence(args: Args) -> Result<ProtonReturn, Error> {
 	let music_file_path = Path::new(&music_file);
 	let seq_duration = args.arg_seq_duration.unwrap();
 	let layout_id = args.arg_layout_id;
-	let data_dao = try!(dao::DataDaoPostgres::new());
-	let layout_dao = try!(dao::LayoutDaoPostgres::new());
-	let perm_dao = try!(dao::PermissionDaoPostgres::new());
-	let sequence_dao = try!(dao::SequenceDaoPostgres::new());
-	let user_dao = try!(dao::UserDaoPostgres::new());
 
 	// Check that the admin has sufficient privileges
-    let valid_permissions = vec![PermissionEnum::Administrate];
-    let _ = try!(utils::check_valid_permission(
-        &perm_dao,
-        &user_dao,
-        admin_key_path,
-        &valid_permissions));
+	let valid_permissions = vec![PermissionEnum::Administrate];
+	let _ = try!(utils::check_valid_permission(
+		&dao,
+		admin_key_path,
+		&valid_permissions));
 
 	let seqid = try!(proton_cli::new_sequence(
-		&data_dao,
-		&layout_dao,
-		&sequence_dao,
+		&dao,
 		&name,
 		&music_file_path,
 		seq_duration,
@@ -312,27 +266,24 @@ fn run_new_sequence(args: Args) -> Result<ProtonReturn, Error> {
 }
 
 /// new-user <admin-key> <name>
-fn run_new_user(args: Args) -> Result<ProtonReturn, Error> {
+fn run_new_user<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let admin_key = args.arg_admin_key.unwrap();
 	let admin_key_path = Path::new(&admin_key);
 	let name = args.arg_name.unwrap();
-	let user_dao = try!(dao::UserDaoPostgres::new());
-	let perm_dao = try!(dao::PermissionDaoPostgres::new());
 
 	// See if admin has permission to add user
-    let valid_permissions = vec![PermissionEnum::Administrate];
-    let _ = try!(utils::check_valid_permission(
-        &perm_dao,
-        &user_dao,
-        admin_key_path,
-        &valid_permissions));
+	let valid_permissions = vec![PermissionEnum::Administrate];
+	let _ = try!(utils::check_valid_permission(
+		&dao,
+		admin_key_path,
+		&valid_permissions));
 
-	let public_key = try!(proton_cli::new_user(user_dao, &name));
+	let public_key = try!(proton_cli::new_user(&dao, &name));
 	Ok(ProtonReturn::PublicKey(public_key))
 }
 
 /// new-vixen-sequence <admin-key> <name> <music-file> <seq-duration> <frame-duration> <data-file> <layout-id>
-fn run_new_vixen_sequence(args: Args) -> Result<ProtonReturn, Error> {
+fn run_new_vixen_sequence<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let admin_key = args.arg_admin_key.unwrap();
 	let admin_key_path = Path::new(&admin_key);
 	let name = args.arg_name.unwrap();
@@ -345,31 +296,20 @@ fn run_new_vixen_sequence(args: Args) -> Result<ProtonReturn, Error> {
 	let layout_id = match args.arg_layout_id {
 		Some(lid) => lid,
 		None => {
-			let layout_dao = try!(dao::LayoutDaoPostgres::new());
-			let default_layout = try!(layout_dao.get_default_layout());
+			let default_layout = try!(dao.get_default_layout());
 			default_layout.layout_id
 		},
 	};
-	let channel_dao = try!(dao::ChannelDaoPostgres::new());
-	let data_dao = try!(dao::DataDaoPostgres::new());
-	let layout_dao = try!(dao::LayoutDaoPostgres::new());
-	let perm_dao = try!(dao::PermissionDaoPostgres::new());
-	let sequence_dao = try!(dao::SequenceDaoPostgres::new());
-	let user_dao = try!(dao::UserDaoPostgres::new());
 
 	// Check that the admin has sufficient privileges
-    let valid_permissions = vec![PermissionEnum::Administrate];
-    let _ = try!(utils::check_valid_permission(
-        &perm_dao,
-        &user_dao,
-        admin_key_path,
-        &valid_permissions));
+	let valid_permissions = vec![PermissionEnum::Administrate];
+	let _ = try!(utils::check_valid_permission(
+		&dao,
+		admin_key_path,
+		&valid_permissions));
 
 	let seqid = try!(proton_cli::new_vixen_sequence(
-		&channel_dao,
-		&data_dao,
-		&layout_dao,
-		&sequence_dao,
+		&dao,
 		&name,
 		&music_file_path,
 		seq_duration,
@@ -380,59 +320,50 @@ fn run_new_vixen_sequence(args: Args) -> Result<ProtonReturn, Error> {
 }
 
 /// patch-layout <admin-key> <layout-id> <patch-file>
-fn run_patch_layout(args: Args) -> Result<ProtonReturn, Error> {
+fn run_patch_layout<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let admin_key = args.arg_admin_key.unwrap();
 	let admin_key_path = Path::new(&admin_key);
 	let layout_id = args.arg_layout_id.unwrap();
 	let patch_file = args.arg_patch_file.unwrap();
 	let patch_file_path = Path::new(&patch_file);
 
-	let layout_dao = try!(dao::LayoutDaoPostgres::new());
-	let perm_dao = try!(dao::PermissionDaoPostgres::new());
-	let user_dao = try!(dao::UserDaoPostgres::new());
-
 	// Check that the admin has sufficient privileges
-    let valid_permissions = vec![PermissionEnum::Administrate];
-    let _ = try!(utils::check_valid_permission(
-        &perm_dao,
-        &user_dao,
-        admin_key_path,
-        &valid_permissions));
+	let valid_permissions = vec![PermissionEnum::Administrate];
+	let _ = try!(utils::check_valid_permission(
+		&dao,
+		admin_key_path,
+		&valid_permissions));
 
 	try!(proton_cli::patch_layout(
-		&layout_dao,
+		&dao,
 		layout_id,
 		&patch_file_path));
 	
-	Ok(ProtonReturn::NoReturn)	
+	Ok(ProtonReturn::NoReturn)
 }
 
 /// remove-sequence <admin-key> <proj-name> <seqid>
-fn run_remove_sequence(args: Args) -> Result<ProtonReturn, Error> {
+fn run_remove_sequence<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let admin_key = args.arg_admin_key.unwrap();
 	let admin_key_path = Path::new(&admin_key);
 	let proj_name = args.arg_proj_name.unwrap();
 	let seqid = args.arg_seqid.unwrap();
-	let perm_dao = try!(dao::PermissionDaoPostgres::new());
-	let project_dao = try!(dao::ProjectDaoPostgres::new());
-	let user_dao = try!(dao::UserDaoPostgres::new());
 
 	// Check that the admin has sufficient privileges
-    let valid_permissions = vec![PermissionEnum::Administrate, PermissionEnum::EditSequence(seqid)];
-    let _ = try!(utils::check_valid_permission(
-        &perm_dao,
-        &user_dao,
-        admin_key_path,
-        &valid_permissions));
-    
-	try!(proton_cli::remove_sequence(&project_dao, &proj_name, seqid));
+	let valid_permissions = vec![PermissionEnum::Administrate, PermissionEnum::EditSequence(seqid)];
+	let _ = try!(utils::check_valid_permission(
+		&dao,
+		admin_key_path,
+		&valid_permissions));
+
+	try!(proton_cli::remove_sequence(&dao, &proj_name, seqid));
 	Ok(ProtonReturn::NoReturn)
 }
 
 /// remove-user <admin-key> <uid>
-fn run_remove_user(args: Args) -> Result<ProtonReturn, Error> {
+fn run_remove_user<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let name = args.arg_name.unwrap();
-	try!(proton_cli::remove_user(&name));
+	try!(proton_cli::remove_user(&dao, &name));
 	Ok(ProtonReturn::NoReturn)
 }
 
@@ -440,7 +371,7 @@ fn run_remove_user(args: Args) -> Result<ProtonReturn, Error> {
 /// set-permission <admin-key> (add | remove) <uid> EditSequence <target-sequence>
 /// set-permission <admin-key> (add | remove) <uid> EditSection <target-sequence> <target-section>
 /// set-permission <admin-key> (add | remove) <name> EditSeqSec <target-section>
-fn run_set_permission(args: Args) -> Result<ProtonReturn, Error> {
+fn run_set_permission<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let admin_key = args.arg_admin_key.unwrap();
 	let admin_key_path = Path::new(&admin_key);
 	let added = env::args().nth(3).unwrap() == "add";
@@ -450,6 +381,7 @@ fn run_set_permission(args: Args) -> Result<ProtonReturn, Error> {
 	let target_section = args.arg_target_section;
 
 	try!(proton_cli::set_permission(
+		&dao,
 		&admin_key_path,
 		added,
 		uid,
@@ -460,27 +392,21 @@ fn run_set_permission(args: Args) -> Result<ProtonReturn, Error> {
 }
 
 /// set-sequence-layout <admin-key> <seqid> <layout-id>
-fn run_set_sequence_layout(args: Args) -> Result<ProtonReturn, Error> {
+fn run_set_sequence_layout<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let admin_key = args.arg_admin_key.unwrap();
 	let admin_key_path = Path::new(&admin_key);
 	let seqid = args.arg_seqid.unwrap();
 	let layout_id = args.arg_layout_id.unwrap();
-	let layout_dao = try!(dao::LayoutDaoPostgres::new());
-	let perm_dao = try!(dao::PermissionDaoPostgres::new());
-	let seq_dao = try!(dao::SequenceDaoPostgres::new());
-	let user_dao = try!(dao::UserDaoPostgres::new());
 
 	// Check that the admin has sufficient privileges
-    let valid_permissions = vec![PermissionEnum::Administrate];
-    let _ = try!(utils::check_valid_permission(
-        &perm_dao,
-        &user_dao,
-        admin_key_path,
-        &valid_permissions));
+	let valid_permissions = vec![PermissionEnum::Administrate];
+	let _ = try!(utils::check_valid_permission(
+		&dao,
+		admin_key_path,
+		&valid_permissions));
 
 	try!(proton_cli::set_sequence_layout(
-		&layout_dao,
-		&seq_dao,
+		&dao,
 		layout_id,
 		seqid));
 	Ok(ProtonReturn::NoReturn)

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,9 +209,7 @@ fn run_insert_sequence<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonRetur
 /// list-permissions <uid>
 fn run_list_permissions<PD: ProtonDao>(args: Args, dao: PD) -> Result<ProtonReturn, Error> {
 	let uid = args.arg_uid.unwrap();
-	let permissions = try!(
-		proton_cli::get_permissions(&dao, uid)
-	);
+	let permissions = try!(proton_cli::get_permissions(&dao, uid));
 	println!("{}", json::as_pretty_json(&permissions));
 	Ok(ProtonReturn::NoReturn)
 }

--- a/src/permissions.rs
+++ b/src/permissions.rs
@@ -2,18 +2,22 @@ use std::path::Path;
 
 use error::Error;
 use project_types::Permission;
-use dao::PermissionDao;
+use dao::ProtonDao;
 
 
 /// [INCOMPLETE] Gets the permissions a user has
-pub fn get_permissions<P: AsRef<Path>, PD: PermissionDao> (pdao: PD, uid: u32
+pub fn get_permissions<PD: ProtonDao> (
+    dao: &PD,
+    uid: u32
 ) -> Result<Vec<Permission>, Error> {
-    pdao.get_all_permissions(uid)
+
+    dao.get_all_permissions(uid)
 }
 
 /// [INCOMPLETE] Sets a user's permission
 #[allow(unused_variables)]
-pub fn set_permission<P: AsRef<Path>> (
+pub fn set_permission<P: AsRef<Path>, PD: ProtonDao> (
+    dao: &PD,
     admin_key_path: P,
     add: bool,
     target_uid: u32,

--- a/src/project_types/file_layout.rs
+++ b/src/project_types/file_layout.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use dao::{ChannelDao, FixtureDao};
+use dao::ProtonDao;
 use error::Error;
 use project_types::{Channel, Fixture};
 
@@ -111,10 +111,9 @@ impl FileLayout {
 
     /// Creates new channels and fixtures based on this FileLayout's data. Part of 
     /// this process is grouping the channels into fixtures.
-    pub fn create_new_parts<CD: ChannelDao, FD: FixtureDao>(
+    pub fn create_new_parts<PD: ProtonDao>(
         &self,
-        chan_dao: &CD,
-        fix_dao: &FD
+        dao: &PD,
     ) -> Result<(Vec<Channel>, Vec<Fixture>), Error> {
     
         let mut channels = Vec::new();
@@ -125,7 +124,7 @@ impl FileLayout {
             if c.channelName != "Spare" && c.channelName != "X" {
                 let location = try!(FileLayout::layout_get_i32_tuple(&c.location));
                 let rotation = try!(FileLayout::layout_get_i32_tuple(&c.rotation));
-                let channel = try!(chan_dao.new_channel(
+                let channel = try!(dao.new_channel(
                     &c.channelName,
                     c.num_primary,
                     c.num_secondary,
@@ -148,7 +147,7 @@ impl FileLayout {
         let mut fixtures = Vec::new();
         for (fix_name, fix_chan_ids) in &fixture_names {
             // TODO: Calculate center and width/height of fixture
-            let fixture = try!(fix_dao.new_fixture(
+            let fixture = try!(dao.new_fixture(
                 fix_name,
                 (0,0,0),
                 (0,0,0),

--- a/src/user.rs
+++ b/src/user.rs
@@ -1,15 +1,15 @@
 //! This module manages project users
 use std::path::Path;
 
-use dao::{UserDao};
+use dao::{ProtonDao};
 use error::Error;
 use project_types::User;
 use utils;
 
 
 /// Lookup and return a user from a public key
-pub fn get_user<P: AsRef<Path>, UD: UserDao>(
-    user_dao: UD,
+pub fn get_user<P: AsRef<Path>, PD: ProtonDao> (
+    dao: &PD,
     public_key_path: P
 ) -> Result<User, Error> {
     
@@ -21,16 +21,16 @@ pub fn get_user<P: AsRef<Path>, UD: UserDao>(
     }
 
     // Lookup uid
-    let uid = try!(user_dao.get_user_id(&public_key_str));
+    let uid = try!(dao.get_user_id(&public_key_str));
 
     // Get user
-    let user = try!(user_dao.get_user(uid));
+    let user = try!(dao.get_user(uid));
 
     Ok(user)
 }
 
-pub fn new_user<UD: UserDao>(
-    user_dao: UD,
+pub fn new_user<PD: ProtonDao> (
+    dao: &PD,
     name: &str
 ) -> Result<String, Error> {
 
@@ -38,7 +38,7 @@ pub fn new_user<UD: UserDao>(
     let (user_pub_key, user_private_key) = try!(utils::create_pub_priv_keys());
 
     // Add user
-    let _ = try!(user_dao.add_user(name, &user_private_key, &user_pub_key));
+    let _ = try!(dao.add_user(name, &user_private_key, &user_pub_key));
 
     // Return public key
     Ok(user_pub_key)
@@ -46,7 +46,8 @@ pub fn new_user<UD: UserDao>(
 
 /// Removes a user
 #[allow(unused_variables)]
-pub fn remove_user(
+pub fn remove_user<PD: ProtonDao> (
+    dao: &PD,
     name: &str
 ) -> Result<(), Error> {
 

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -6,7 +6,7 @@ use openssl::rsa;
 use openssl::pkey;
 use rustc_serialize::json;
 
-use dao::{PermissionDao, UserDao};
+use dao::ProtonDao;
 use project_types::PermissionEnum;
 use error::Error;
 
@@ -47,17 +47,16 @@ pub fn validate_rsa_pub_key(pub_key: &str) -> bool {
 /// Checks if the user with a public key at the given path has
 /// one of the given valid permissions
 /// Returns this user if found and has permission, else error
-pub fn check_valid_permission<P: AsRef<Path>, PD: PermissionDao, UD: UserDao>(
-    perm_dao: &PD,
-    user_dao: &UD,
+pub fn check_valid_permission<P: AsRef<Path>, PD: ProtonDao>(
+    dao: &PD,
     public_key_path: P,
     valid_permissions: &Vec<PermissionEnum>
 ) -> Result<u32, Error> {
     
     if valid_permissions.len() > 0 {
         let public_key = try!(file_as_string(public_key_path));
-        let uid = try!(user_dao.get_user_id(&public_key));
-        let permissions = try!(perm_dao.get_all_permissions(uid));
+        let uid = try!(dao.get_user_id(&public_key));
+        let permissions = try!(dao.get_all_permissions(uid));
         for permission in permissions {
             if valid_permissions.contains(&permission.permission) {
                 return Ok(uid);


### PR DESCRIPTION
Background:
The DAOs (Data Access Objects) are an abstraction between proton-cli and the underlying data store containing all the proton data (sequences, users, etc). When I got them to work initially it was a little hackish, with specific DAOs being passed around for each table in the Postgresql database. 

This:
This PR (Pull Request) keeps the table-specific daos separate to make their implementation easier, but also adds the new trait ProtonDao which is an aggregate of all the table-specific DAOs. This way the specific DAO being implemented can be chosen in one spot in main.rs, and function calls become much simpler (just pass in one dao instead of 2, 3, 4, etc.).

Compiles and runs on my machine.

@schmiter @webe0586 @JPPropenator if/when this gets pulled into master you will probably have to merge with your changes, since this change touched a lot of places. I can help with that when we get there.