### PR TITLE
Relaxed layout naming requirements

### DIFF
--- a/src/dao/sequence_dao_postgres.rs
+++ b/src/dao/sequence_dao_postgres.rs
@@ -8,7 +8,7 @@ impl SequenceDao for DaoPostgres {
     fn get_channel_ids(&self, seqid: u32) -> Result<Vec<u32>, Error> {
         let query = "SELECT chanid FROM \
             (SELECT unnest(channels) AS cid FROM sequences s \
-            INNER JOIN layouts l ON l.layoutid = s.layout_id \
+            INNER JOIN layouts l ON l.layoutid = s.layoutid \
             INNER JOIN fixtures f ON f.fixid = ANY(l.fixtures) \
             WHERE s.seqid = $1) chan_ids \
         INNER JOIN channels c ON c.chanid = chan_ids.cid \
@@ -26,7 +26,7 @@ impl SequenceDao for DaoPostgres {
     }
 
     fn get_sequence(&self, seqid: u32) -> Result<Sequence, Error> {
-        let query = "SELECT name,music_file_name,music_dur_sec,frame_dur_ms,num_frames,layout_id \
+        let query = "SELECT name,music_file_name,music_dur_sec,frame_dur_ms,num_frames,layoutid \
         FROM sequences WHERE seqid = $1";
         let results = try!(
             self.conn.query(query, &[&(seqid as i32)])
@@ -56,7 +56,7 @@ impl SequenceDao for DaoPostgres {
     }
 
     fn get_last_sequence(&self, name: &str) -> Result<Sequence, Error> {
-        let query = "SELECT seqid,music_file_name,music_dur_sec,frame_dur_ms,num_frames,layout_id \
+        let query = "SELECT seqid,music_file_name,music_dur_sec,frame_dur_ms,num_frames,layoutid \
         FROM sequences WHERE name = $1 ORDER BY seqid DESC";
         let results = try!(
             self.conn.query(query, &[&name.to_owned()])
@@ -85,7 +85,7 @@ impl SequenceDao for DaoPostgres {
 
     fn new_sequence(&self, sequence: &Sequence) -> Result<Sequence, Error> {
         let statement = "INSERT INTO sequences (name,music_file_name,music_dur_sec,\
-            frame_dur_ms,num_frames,layout_id) VALUES ($1,$2,$3,$4,$5,$6)";
+            frame_dur_ms,num_frames,layoutid) VALUES ($1,$2,$3,$4,$5,$6)";
         let music_dur = sequence.music_duration_sec as i32;
         let frame_dur = sequence.frame_duration_ms as i32;
         let num_frames = sequence.num_frames as i32;
@@ -115,7 +115,7 @@ impl SequenceDao for DaoPostgres {
     }
 
     fn set_layout(&self, seqid: u32, layout_id: u32) -> Result<(), Error> {
-        let statement = "UPDATE sequences SET layout_id = $1 WHERE seqid = $2";
+        let statement = "UPDATE sequences SET layoutid = $1 WHERE seqid = $2";
         let _ = try!(
             self.conn.execute(
                 statement,

--- a/src/project_types/file_layout.rs
+++ b/src/project_types/file_layout.rs
@@ -60,11 +60,15 @@ impl FileLayout {
         if self.layoutName.len() > 64 {
             return Err(Error::InvalidLayout(String::from("Layout name cannot be longer than 64 characters")))
         }
-        if !self.layoutName.chars().all(char::is_alphanumeric) {
-            return Err(Error::InvalidLayout(String::from("Layout name has to be alphanumeric: ") + &self.layoutName))   
+        if !self.layoutName.chars().all(|c| char::is_alphanumeric(c) || c == ' ') {
+            return Err(Error::InvalidLayout(String::from("Layout name has to contain alphanumerics or \" \": ") + &self.layoutName))
         }
 
         for channel in &self.channels {
+            // Skip empty channels (things moved for 2017 show)
+            if channel.channelName.trim() == "" {
+                continue;
+            }
 
             // Make sure internal channel > 0 (indexed same as DMX)
             if channel.internalChannel < 1 {
@@ -86,24 +90,24 @@ impl FileLayout {
             if channel.channelName.len() > 40 {
                 return Err(Error::InvalidLayout(String::from("Channel name cannot be longer than 40 characters")));
             }
-            if !channel.channelName.chars().all(|c| c.is_alphanumeric() || c == ' ') {
-                return Err(Error::InvalidLayout(String::from("Channel name has to be alphanumeric: ") + &channel.channelName));
+            if !channel.channelName.chars().all(|c| c.is_alphanumeric() || " -/_".contains(c)) {
+                return Err(Error::InvalidLayout(String::from("Channel name can only contain alphanumerics or \"- /_\" : ") + &channel.channelName))
             }
 
             // Validate name not too long and only alphanumerics or spaces
             if channel.fixtureName.len() > 40 {
                 return Err(Error::InvalidLayout(String::from("Fixture name cannot be longer than 40 characters")))
             }
-            if !channel.fixtureName.chars().all(|c| c.is_alphanumeric() || c == ' ') {
-                return Err(Error::InvalidLayout(String::from("Fixture name has to be alphanumeric: ") + &channel.fixtureName))   
+            if !channel.fixtureName.chars().all(|c| c.is_alphanumeric() || " -/_".contains(c)) {
+                return Err(Error::InvalidLayout(String::from("Fixture name can only contain alphanumerics or \"- /_\" : ") + &channel.fixtureName))
             }
 
             // Validate color not too long and only alphanumerics or spaces
             if channel.color.len() > 16 {
                 return Err(Error::InvalidLayout(String::from("Color cannot be longer than 16 characters")))
             }
-            if !channel.color.chars().all(|c| c.is_alphanumeric() || c == ' ') {
-                return Err(Error::InvalidLayout(String::from("Color has to be alphanumeric")))   
+            if !channel.color.chars().all(|c| c.is_alphanumeric() || " -/_".contains(c)) {
+                return Err(Error::InvalidLayout(String::from("Color can only contain alphanumerics or \"- /_\"")))
             }
         }
         Ok(())


### PR DESCRIPTION
Channels in Vixen profiles sometimes include slashes, spaces, dashes, and underscores. These are safe characters to have present (and most are present in this year's profile), so the constraints on valid characters in channel names have been relaxed. Some constraints on other names have also been relaxed while I was there.

Also, channels with empty names are present in this year's profile, and represent unsequenced channels. These channels are dropped.

Side note, the unique constraint on channel names has been removed.